### PR TITLE
Add tests for reference priming in aggregation builder

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Aggregation.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Aggregation.php
@@ -58,13 +58,13 @@ final class Aggregation implements IteratorAggregate
             $cursor = new HydratingIterator($cursor, $this->dm->getUnitOfWork(), $this->classMetadata);
         }
 
+        $cursor = $this->rewindable ? new CachingIterator($cursor) : new UnrewindableIterator($cursor);
+
         if (! empty($this->primers)) {
             $referencePrimer = new ReferencePrimer($this->dm, $this->dm->getUnitOfWork());
             $cursor          = new PrimingIterator($cursor, $this->classMetadata, $referencePrimer, $this->primers, []);
         }
 
-
-
-        return $this->rewindable ? new CachingIterator($cursor) : new UnrewindableIterator($cursor);
+        return $cursor;
     }
 }


### PR DESCRIPTION
Only tested the happy case - might want to test behaviour when `hydrate()` was never called on the builder.